### PR TITLE
Fix some Clippy warnings

### DIFF
--- a/src/malloc/expand_heap.rs
+++ b/src/malloc/expand_heap.rs
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn __expand_heap(pn: *mut size_t) -> *mut c_void {
 
     let area = __mmap(ptr::null_mut(),
                       n,
-                      PROT_READ | PROT_READ,
+                      PROT_READ | PROT_WRITE,
                       MAP_PRIVATE | MAP_ANONYMOUS,
                       -1,
                       0);

--- a/src/malloc/malloc.rs
+++ b/src/malloc/malloc.rs
@@ -401,14 +401,14 @@ impl Heap {
             n -= SIZE_ALIGN;
             p = (p as *mut u8).offset(SIZE_ALIGN as isize) as *mut c_void;
             w = Chunk::from_mem(p);
-            (*w).psize = 0 | 1;
+            (*w).psize = 1;
         }
 
         // Record new heap end and fill in footer.
         *end = (p as *mut u8).offset(n as isize) as *mut c_void;
         w = Chunk::from_mem(*end);
         (*w).psize = n | 1;
-        (*w).csize = 0 | 1;
+        (*w).csize = 1;
 
         // Fill in header, which may be new or may be replacing a
         // zero-size sentinel header at the old end-of-heap.
@@ -532,7 +532,7 @@ impl Heap {
 
         (*s).csize = n | 1;
 
-        return true;
+        true
     }
 
     unsafe fn adjust_size(&self, n: *mut usize) -> c_int {
@@ -540,15 +540,15 @@ impl Heap {
         if *n - 1 > isize::MAX as usize - SIZE_ALIGN as usize - PAGE_SIZE as usize {
             if *n != 0 {
                 set_errno(ENOMEM);
-                return -1;
+                -1
             } else {
                 *n = SIZE_ALIGN;
-                return 0;
+                0
             }
+        } else {
+            *n = (*n + OVERHEAD + SIZE_ALIGN - 1) & SIZE_MASK;
+            0
         }
-
-        *n = (*n + OVERHEAD + SIZE_ALIGN - 1) & SIZE_MASK;
-        return 0;
     }
 }
 

--- a/src/string/strcmp.rs
+++ b/src/string/strcmp.rs
@@ -12,5 +12,5 @@ pub unsafe extern "C" fn strcmp(l: *const c_schar, r: *const c_schar) -> c_int {
             return (lc - rc) as c_int;
         }
     }
-    return i32::MAX;
+    i32::MAX
 }

--- a/src/string/strlen.rs
+++ b/src/string/strlen.rs
@@ -10,5 +10,5 @@ pub unsafe extern "C" fn strlen(s: *const c_schar) -> size_t {
             return i as usize;
         }
     }
-    return usize::MAX;
+    usize::MAX
 }

--- a/src/syscall_mgt.rs
+++ b/src/syscall_mgt.rs
@@ -10,7 +10,7 @@ pub unsafe fn syscall_return(code: usize) -> usize {
         set_errno(-(code as c_int));
         (-1isize) as usize
     } else {
-        transmute(code)
+        code
     }
 }
 

--- a/src/time/clock.rs
+++ b/src/time/clock.rs
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn clock_gettime(clock: clockid_t, spec: &mut timespec) ->
     if r == -ENOSYS {
         if clock == CLOCK_REALTIME {
             syscall!(GETTIMEOFDAY, spec as *mut timespec, 0);
-            spec.tv_nsec = spec.tv_nsec * 1000;
+            spec.tv_nsec *= 1000;
             return 0;
         }
         r = -EINVAL;


### PR DESCRIPTION
Mostly some small unidiomatic stuffs but there was one interesting actual bug:

``` diff
      let area = __mmap(ptr::null_mut(),
                       n,
-                      PROT_READ | PROT_READ,
+                      PROT_READ | PROT_WRITE,
                       MAP_PRIVATE | MAP_ANONYMOUS,
                       -1,
                       0); 
```
