### PR TITLE
Indicate weak linkage for symbols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 env:
   global:
-    - RUSTFMT_VERSION=0.5.0
+    - RUSTFMT_VERSION=0.7.1
 cache:
   directories:
   - $HOME/.cargo/bin

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -74,6 +74,7 @@ pub unsafe fn mremap_helper(old_address: *mut c_void,
     syscall!(MREMAP, old_address, old_len, new_len, flags, new_address) as *mut c_void
 }
 
+#[linkage = "weak"]
 #[no_mangle]
 pub unsafe extern "C" fn madvise(address: *mut c_void, len: usize, advice: c_int) -> c_int {
     syscall!(MADVISE, address, len, advice) as c_int
@@ -99,9 +100,11 @@ pub unsafe extern "C" fn mlockall(flags: c_int) -> c_int { syscall!(MLOCKALL, fl
 
 
 // aliases
+#[linkage = "weak"]
 #[no_mangle]
 pub unsafe extern "C" fn munmap(start: *mut c_void, len: size_t) -> c_int { __munmap(start, len) }
 
+#[linkage = "weak"]
 #[no_mangle]
 pub unsafe extern "C" fn mmap(start: *mut c_void,
                               len: size_t,
@@ -113,6 +116,7 @@ pub unsafe extern "C" fn mmap(start: *mut c_void,
     __mmap(start, len, prot, flags, fd, off)
 }
 
+#[linkage = "weak"]
 #[no_mangle]
 pub unsafe extern "C" fn mmap64(start: *mut c_void,
                                 len: size_t,
@@ -124,6 +128,7 @@ pub unsafe extern "C" fn mmap64(start: *mut c_void,
     __mmap(start, len, prot, flags, fd, off)
 }
 
+#[linkage = "weak"]
 #[no_mangle]
 pub unsafe extern "C" fn mremap(old_address: *mut c_void,
                                 old_len: size_t,

--- a/src/string/stpcpy.rs
+++ b/src/string/stpcpy.rs
@@ -1,5 +1,6 @@
 use c_types::*;
 
+#[linkage = "weak"]
 #[no_mangle]
 pub unsafe extern "C" fn stpcpy(dest: *mut c_schar, source: *const c_schar) -> *mut c_schar {
     // TODO(adam) compare and copy as word-size chunks

--- a/src/thread/vmlock.rs
+++ b/src/thread/vmlock.rs
@@ -4,6 +4,7 @@ use thread::{__wait, __wake};
 
 static mut LOCK: [c_int; 2] = [0, 0];
 
+#[linkage = "weak"]
 #[no_mangle]
 pub unsafe extern "C" fn __vm_wait() {
     let mut tmp = LOCK[0];

--- a/src/time/clock.rs
+++ b/src/time/clock.rs
@@ -23,6 +23,7 @@ pub unsafe extern "C" fn __clock_gettime(clock: clockid_t, spec: &mut timespec) 
     clock_gettime(clock, spec)
 }
 
+#[linkage = "weak"]
 #[no_mangle]
 pub unsafe extern "C" fn clock_gettime(clock: clockid_t, spec: &mut timespec) -> c_int {
     let mut r = syscall!(CLOCK_GETTIME, clock, spec as *mut timespec) as c_int;


### PR DESCRIPTION
The items marked weak here are exactly those marked weak in musl.

It seems like rustc doesn't actually output symbols with weak linkage: this commit is inspired by rlibc, but the symbols in that create aren't output as weak even though they are marked as such in source.

In any event, marking them weak is documentation, and when/if the regression (if that's what it is) for weak linkage gets fixed, rusl will benefit.