### PR TITLE
Port easy exits

### DIFF
--- a/ported_objects
+++ b/ported_objects
@@ -1,3 +1,5 @@
+_Exit.o
+_exit.o
 __errno_location.o
 __wait.o
 access.o
@@ -13,6 +15,7 @@ clock_nanosleep.o
 clock_settime.o
 close.o
 ctermid.o
+exit.o
 expand_heap.o
 madvise.o
 malloc.o
@@ -26,6 +29,7 @@ mlockall.o
 mmap.o
 mremap.o
 munmap.o
+quick_exit.o
 stpcpy.o
 strcmp.o
 strcpy.o

--- a/src/exit/_Exit.rs
+++ b/src/exit/_Exit.rs
@@ -1,8 +1,10 @@
 use c_types::c_int;
 
 #[no_mangle]
-pub unsafe extern "C" fn _Exit(ec: c_int) -> ! {
-    syscall!(EXIT_GROUP, ec);
-    syscall!(EXIT, ec);
+pub extern "C" fn _Exit(ec: c_int) -> ! {
+    unsafe {
+        syscall!(EXIT_GROUP, ec);
+        syscall!(EXIT, ec);
+    }
     loop {}
 }

--- a/src/exit/_Exit.rs
+++ b/src/exit/_Exit.rs
@@ -1,0 +1,8 @@
+use c_types::c_int;
+
+#[no_mangle]
+pub unsafe extern "C" fn _Exit(ec: c_int) -> ! {
+    syscall!(EXIT_GROUP, ec);
+    syscall!(EXIT, ec);
+    loop {}
+}

--- a/src/exit/_Exit.rs
+++ b/src/exit/_Exit.rs
@@ -6,5 +6,10 @@ pub extern "C" fn _Exit(ec: c_int) -> ! {
         syscall!(EXIT_GROUP, ec);
         syscall!(EXIT, ec);
     }
+    // The loop, while technically unreachable, ensures this function
+    // is divergent. The syscall above returns (), so this code
+    // wouldn't typecheck if we didn't have this infinite loop. See
+    // this musl changeset for similar discussion:
+    // http://git.musl-libc.org/cgit/musl/commit/src/exit/_Exit.c?id=0c05bd3a9c165cf2f0b9d6fa23a1f96532ddcdb3
     loop {}
 }

--- a/src/exit/exit.rs
+++ b/src/exit/exit.rs
@@ -1,0 +1,28 @@
+use c_types::c_int;
+use super::_Exit::_Exit;
+
+#[linkage = "weak"]
+#[no_mangle]
+pub unsafe extern "C" fn __funcs_on_exit() {}
+
+#[linkage = "weak"]
+#[no_mangle]
+pub unsafe extern "C" fn __stdio_exit() {}
+
+#[linkage = "weak"]
+#[no_mangle]
+pub unsafe extern "C" fn _fini() {}
+
+#[linkage = "weak"]
+#[no_mangle]
+pub unsafe extern "C" fn __libc_exit_fini() {
+    _fini()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn exit(code: c_int) -> ! {
+    __funcs_on_exit();
+    __libc_exit_fini();
+    __stdio_exit();
+    _Exit(code)
+}

--- a/src/exit/exit.rs
+++ b/src/exit/exit.rs
@@ -16,6 +16,14 @@ pub extern "C" fn _fini() {}
 #[linkage = "weak"]
 #[no_mangle]
 pub extern "C" fn __libc_exit_fini() {
+    // TODO dark magic goes here, seemingly for dynlink's benefit
+    // See http://git.musl-libc.org/cgit/musl/commit/src/exit/exit.c?id=7586360badcae6e73f04eb1b8189ce630281c4b2
+    // and http://git.musl-libc.org/cgit/musl/commit/src/exit/exit.c?id=19caa25d0a8e587bb89b79c3f629085548709dd4
+    // for interesting discussion about how musl handles this function.
+    // Really, we should iterate through __fini_array_start..__fini_array_end,
+    // executing each function. But it requires annoying pointer
+    // manipulation that I wasn't sure we needed yet, since we aren't
+    // porting dynlink right now.
     _fini()
 }
 
@@ -24,5 +32,7 @@ pub extern "C" fn exit(code: c_int) -> ! {
     __funcs_on_exit();
     __libc_exit_fini();
     __stdio_exit();
+    // The functions above are weakly-aliased because the dynlinker
+    // might provide defs for them. Meanwhile, we provide dummy fns.
     _Exit(code)
 }

--- a/src/exit/exit.rs
+++ b/src/exit/exit.rs
@@ -3,24 +3,24 @@ use super::_Exit::_Exit;
 
 #[linkage = "weak"]
 #[no_mangle]
-pub unsafe extern "C" fn __funcs_on_exit() {}
+pub extern "C" fn __funcs_on_exit() {}
 
 #[linkage = "weak"]
 #[no_mangle]
-pub unsafe extern "C" fn __stdio_exit() {}
+pub extern "C" fn __stdio_exit() {}
 
 #[linkage = "weak"]
 #[no_mangle]
-pub unsafe extern "C" fn _fini() {}
+pub extern "C" fn _fini() {}
 
 #[linkage = "weak"]
 #[no_mangle]
-pub unsafe extern "C" fn __libc_exit_fini() {
+pub extern "C" fn __libc_exit_fini() {
     _fini()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn exit(code: c_int) -> ! {
+pub extern "C" fn exit(code: c_int) -> ! {
     __funcs_on_exit();
     __libc_exit_fini();
     __stdio_exit();

--- a/src/exit/mod.rs
+++ b/src/exit/mod.rs
@@ -1,0 +1,3 @@
+pub mod _Exit;
+pub mod exit;
+pub mod quick_exit;

--- a/src/exit/quick_exit.rs
+++ b/src/exit/quick_exit.rs
@@ -3,10 +3,10 @@ use super::_Exit::_Exit;
 
 #[linkage = "weak"]
 #[no_mangle]
-pub unsafe extern "C" fn __funcs_on_quick_exit() {}
+pub extern "C" fn __funcs_on_quick_exit() {}
 
 #[no_mangle]
-pub unsafe extern "C" fn quick_exit(code: c_int) {
+pub extern "C" fn quick_exit(code: c_int) {
     __funcs_on_quick_exit();
     _Exit(code)
 }

--- a/src/exit/quick_exit.rs
+++ b/src/exit/quick_exit.rs
@@ -1,0 +1,12 @@
+use c_types::c_int;
+use super::_Exit::_Exit;
+
+#[linkage = "weak"]
+#[no_mangle]
+pub unsafe extern "C" fn __funcs_on_quick_exit() {}
+
+#[no_mangle]
+pub unsafe extern "C" fn quick_exit(code: c_int) {
+    __funcs_on_quick_exit();
+    _Exit(code)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub use rlibc::*;
 #[macro_use]
 pub mod syscall_mgt;
 
+pub mod exit;
 pub mod malloc;
 pub mod mmap;
 pub mod string;

--- a/src/unistd/_exit.rs
+++ b/src/unistd/_exit.rs
@@ -1,0 +1,7 @@
+use c_types::c_int;
+use ::exit::_Exit::_Exit;
+
+#[no_mangle]
+pub unsafe extern "C" fn _exit(status: c_int) -> ! {
+    _Exit(status)
+}

--- a/src/unistd/_exit.rs
+++ b/src/unistd/_exit.rs
@@ -2,6 +2,6 @@ use c_types::c_int;
 use ::exit::_Exit::_Exit;
 
 #[no_mangle]
-pub unsafe extern "C" fn _exit(status: c_int) -> ! {
+pub extern "C" fn _exit(status: c_int) -> ! {
     _Exit(status)
 }

--- a/src/unistd/mod.rs
+++ b/src/unistd/mod.rs
@@ -1,3 +1,4 @@
+pub mod _exit;
 pub mod access;
 pub mod acct;
 pub mod alarm;


### PR DESCRIPTION
some of the mess in exit.rs is meant for dynlink. Read commit
messages for exit.c and friends for full details and
justifications.