### PR TITLE
Implement dup and dup2

### DIFF
--- a/ported_objects
+++ b/ported_objects
@@ -15,6 +15,8 @@ clock_nanosleep.o
 clock_settime.o
 close.o
 ctermid.o
+dup.o
+dup2.o
 exit.o
 expand_heap.o
 madvise.o

--- a/src/unistd/dup.rs
+++ b/src/unistd/dup.rs
@@ -1,0 +1,8 @@
+use c_types::*;
+
+#[no_mangle]
+pub extern "C" fn dup(fd: c_int) -> c_int {
+    unsafe {
+        syscall!(DUP, fd) as c_int
+    }
+}

--- a/src/unistd/dup2.rs
+++ b/src/unistd/dup2.rs
@@ -1,0 +1,16 @@
+use c_types::*;
+use platform::errno::EBUSY;
+use syscall_mgt::syscall_return;
+
+// TODO impl for non-dup2 systems (e.g. aarch64, or1k)
+#[no_mangle]
+pub extern "C" fn dup2(old: c_int, new: c_int) -> c_int {
+    let mut r;
+    loop {
+        r = unsafe { syscall!(DUP2, old, new) };
+        if (r as c_int) != -EBUSY {
+            break;
+        }
+    }
+    unsafe { syscall_return(r) as c_int }
+}

--- a/src/unistd/mod.rs
+++ b/src/unistd/mod.rs
@@ -6,3 +6,5 @@ pub mod chdir;
 pub mod chown;
 pub mod close;
 pub mod ctermid;
+pub mod dup;
+pub mod dup2;


### PR DESCRIPTION
These two functions don't need fcntl, so they're easy. Some systems
don't have DUP2 syscall, though, so if we want to implement dup2 for
them, we will need to abstract over platforms here.