### PR TITLE
Don't use libstd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rlibc = "1.0.0"
 spin = "0.4.5"
 sc = "0.1.5"
 va_list = { version = "0.1.0", features = ["no_std"] }
-compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-builtins" }
+compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-builtins", rev = "0507842b248b29d18855042544cf209371ea17c1" }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,12 @@ name = "rusl"
 crate-type = ["staticlib", "dylib"]
 
 [dependencies]
-lazy_static = { version = "0.2.1", features = ["spin_no_std"] }
+lazy_static = { version = "0.2.2", features = ["spin_no_std"] }
 rlibc = "1.0.0"
-spin = "0.4.0"
-syscall = "0.2.1"
-va_list = "0.0.3"
+spin = "0.4.5"
+sc = "0.1.5"
+va_list = { version = "0.1.0", features = ["no_std"] }
+compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-builtins" }
 
 [profile.dev]
 panic = "abort"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,14 @@
 #![no_std]
-#![feature(asm, const_fn, lang_items, linkage)]
+#![feature(asm, const_fn, lang_items, linkage, compiler_builtins_lib)]
 
 #![allow(non_camel_case_types)]
 
+extern crate compiler_builtins;
 #[macro_use]
 extern crate lazy_static;
 extern crate rlibc;
 extern crate spin;
-extern crate syscall;
+extern crate sc as syscall;
 extern crate va_list;
 
 pub use rlibc::*;
@@ -34,3 +35,8 @@ pub use platform::environ;
 pub use platform::mman;
 pub use platform::pthread;
 pub use platform::signal;
+
+#[cfg(not(test))]
+#[lang = "panic_fmt"]
+#[no_mangle]
+extern "C" fn panic_fmt() {}


### PR DESCRIPTION
The dependency, va_list, has a feature (no_std) which stops it from
pulling in libstd. We weren't using it. Now we are. Now rustc won't
secretly link rusl with libstd.

We also need to provide intrinsics via compiler_builtins, and I took
the opportunity to update dependencies.

Fixes #21 