### PR TITLE
[WIP] Implement open

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["staticlib", "dylib"]
 
 [dependencies]
 lazy_static = { version = "0.2.2", features = ["spin_no_std"] }
+libc = { version = "0.2", default-features = false }
 rlibc = "1.0.0"
 spin = "0.4.5"
 sc = "0.1.5"

--- a/ported_objects
+++ b/ported_objects
@@ -31,6 +31,7 @@ mlockall.o
 mmap.o
 mremap.o
 munmap.o
+open.o
 quick_exit.o
 stpcpy.o
 strcmp.o

--- a/src/fcntl/constants.rs
+++ b/src/fcntl/constants.rs
@@ -1,0 +1,16 @@
+use libc::c_int;
+
+// These constants don't appear in rust-lang/libc, so we define them here
+// because musl defines them. Maybe we should add them to libc...
+pub const O_LARGEFILE: c_int = 0100000;
+pub const O_NOATIME: c_int = 01000000;
+pub const O_PATH: c_int = 010000000;
+pub const O_TMPFILE: c_int = 020200000;
+
+pub const F_SETSIG: c_int = 10;
+pub const F_GETSIG: c_int = 11;
+
+pub const F_SETOWN_EX: c_int = 15;
+pub const F_GETOWN_EX: c_int = 16;
+
+pub const F_GETOWNER_UIDS: c_int = 17;

--- a/src/fcntl/mod.rs
+++ b/src/fcntl/mod.rs
@@ -1,0 +1,3 @@
+mod constants;
+
+pub mod open;

--- a/src/fcntl/open.rs
+++ b/src/fcntl/open.rs
@@ -1,0 +1,20 @@
+use super::constants::{O_TMPFILE};
+use libc::*;
+use syscall_mgt::syscall_return;
+use va_list::VaList;
+
+#[no_mangle]
+pub unsafe extern "C" fn open(filename: *const c_char, flags: c_int, mut args: VaList) -> c_int {
+    let mut mode: mode_t = 0;
+
+    if (flags & O_CREAT) != 0 || ((flags & O_TMPFILE) == O_TMPFILE) {
+        mode = args.get::<mode_t>();
+    }
+
+    let fd = syscall!(OPEN, filename, flags, mode);
+    if fd >= 0 && (flags & O_CLOEXEC) != 0 {
+        syscall!(FCNTL, fd, F_SETFD, FD_CLOEXEC);
+    }
+
+    syscall_return(fd) as c_int
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 #![no_std]
-#![feature(asm, const_fn, lang_items, linkage, compiler_builtins_lib)]
+#![feature(asm, const_fn, lang_items, linkage, compiler_builtins_lib, core_intrinsics)]
 
 #![allow(non_camel_case_types)]
 
 extern crate compiler_builtins;
 #[macro_use]
 extern crate lazy_static;
+extern crate libc;
 extern crate rlibc;
 extern crate spin;
 extern crate sc as syscall;
@@ -17,6 +18,7 @@ pub use rlibc::*;
 pub mod syscall_mgt;
 
 pub mod exit;
+pub mod fcntl;
 pub mod malloc;
 pub mod mmap;
 pub mod string;
@@ -36,7 +38,9 @@ pub use platform::mman;
 pub use platform::pthread;
 pub use platform::signal;
 
+use core::intrinsics;
 #[cfg(not(test))]
 #[lang = "panic_fmt"]
-#[no_mangle]
-extern "C" fn panic_fmt() {}
+extern "C" fn rust_begin_panic(_msg: core::fmt::Arguments, _file: &'static str, _line: u32) -> ! {
+    unsafe { intrinsics::abort() }
+}


### PR DESCRIPTION
We depend on rust-lang/libc now because it has a larger set of types and
constants than we do right now, and it includes a nice bit of
infrastructure to support a wider array of architectures.

We retained a small number of constants not currently included in libc.

Requires a rather substantial amount of pthreads work (cancelation, for example) before tests will pass.